### PR TITLE
Add border options to tip preferences.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ struct Preferences {
   var systemFontSize          :   CGFloat                =   15
   var textColor               :   UIColor                =   UIColor.whiteColor()
   var bubbleColor             :   UIColor                =   UIColor.redColor()
-  var borderColor             :   UIColor                =   UIColor.clearColor()
-  var borderWidth             :   CGFloat                =   0.0
+  var shouldDrawBorder        :   Bool      			 =	 false
+  var borderColor             :   UIColor                =   UIColor.blueColor()
+  var borderWidth             :   CGFloat                =   1.0
   var arrowPosition           :   ArrowPosition          =   .Bottom
   var font                    :   UIFont?
   var textAlignment           :   NSTextAlignment        =   NSTextAlignment.Center

--- a/Source/EasyTipView.swift
+++ b/Source/EasyTipView.swift
@@ -42,6 +42,7 @@ public class EasyTipView: UIView {
         public var systemFontSize          :   CGFloat
         public var textColor               :   UIColor
         public var bubbleColor             :   UIColor
+        public var shouldDrawBorder        :   Bool
         public var borderColor             :   UIColor
         public var borderWidth             :   CGFloat
         public var arrowPosition           :   ArrowPosition
@@ -52,8 +53,9 @@ public class EasyTipView: UIView {
             systemFontSize = 15
             textColor = UIColor.whiteColor()
             bubbleColor = UIColor.redColor()
-            borderColor = UIColor.clearColor()
-            borderWidth = 0.0
+            shouldDrawBorder = false
+            borderColor = UIColor.blueColor()
+            borderWidth = 1.0
             arrowPosition = .Bottom
             textAlignment = .Center
         }
@@ -355,11 +357,12 @@ public class EasyTipView: UIView {
         CGContextSetFillColorWithColor(context, self.preferences.bubbleColor.CGColor)
         CGContextFillRect(context, self.bounds)
         
-        CGContextAddPath(context, contourPath)
-        CGContextSetStrokeColorWithColor(context, self.preferences.borderColor.CGColor)
-        CGContextSetLineWidth(context, self.preferences.borderWidth)
-        
-        CGContextStrokePath(context)
+        if self.preferences.shouldDrawBorder {
+            CGContextAddPath(context, contourPath)
+            CGContextSetStrokeColorWithColor(context, self.preferences.borderColor.CGColor)
+            CGContextSetLineWidth(context, self.preferences.borderWidth)
+            CGContextStrokePath(context)
+        }
         
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = self.preferences.textAlignment

--- a/Source/EasyTipView.swift
+++ b/Source/EasyTipView.swift
@@ -42,6 +42,8 @@ public class EasyTipView: UIView {
         public var systemFontSize          :   CGFloat
         public var textColor               :   UIColor
         public var bubbleColor             :   UIColor
+        public var borderColor             :   UIColor
+        public var borderWidth             :   CGFloat
         public var arrowPosition           :   ArrowPosition
         public var font                    :   UIFont?
         public var textAlignment           :   NSTextAlignment
@@ -50,6 +52,8 @@ public class EasyTipView: UIView {
             systemFontSize = 15
             textColor = UIColor.whiteColor()
             bubbleColor = UIColor.redColor()
+            borderColor = UIColor.clearColor()
+            borderWidth = 0.0
             arrowPosition = .Bottom
             textAlignment = .Center
         }
@@ -350,6 +354,12 @@ public class EasyTipView: UIView {
         
         CGContextSetFillColorWithColor(context, self.preferences.bubbleColor.CGColor)
         CGContextFillRect(context, self.bounds)
+        
+        CGContextAddPath(context, contourPath)
+        CGContextSetStrokeColorWithColor(context, self.preferences.borderColor.CGColor)
+        CGContextSetLineWidth(context, self.preferences.borderWidth)
+        
+        CGContextStrokePath(context)
         
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = self.preferences.textAlignment


### PR DESCRIPTION
Allows the user to specify a border color and width in preferences. Defaults to invisible.