### PR TITLE
fix positioning when superview is scrollview

### DIFF
--- a/Source/EasyTipView.swift
+++ b/Source/EasyTipView.swift
@@ -355,12 +355,19 @@ public class EasyTipView: UIView {
         var position = preferences.drawing.arrowPosition
         let refViewFrame = CGRect(origin: presentingView!.originWithinDistantSuperView(superview), size: presentingView!.frame.size)
         
-        var frame = computeFrame(arrowPosition: position, refViewFrame: refViewFrame, superviewFrame: superview.frame)
+        let superviewFrame: CGRect
+        if let scrollview = superview as? UIScrollView {
+          superviewFrame = CGRect(origin: scrollview.frame.origin, size: scrollview.contentSize)
+        } else {
+          superviewFrame = superview.frame
+        }
         
-        if !isFrameValid(frame, forRefViewFrame: refViewFrame, withinSuperviewFrame: superview.frame) {
+        var frame = computeFrame(arrowPosition: position, refViewFrame: refViewFrame, superviewFrame: superviewFrame)
+        
+        if !isFrameValid(frame, forRefViewFrame: refViewFrame, withinSuperviewFrame: superviewFrame) {
             for value in ArrowPosition.allValues where value != position {
-                let newFrame = computeFrame(arrowPosition: value, refViewFrame: refViewFrame, superviewFrame: superview.frame)
-                if isFrameValid(newFrame, forRefViewFrame: refViewFrame, withinSuperviewFrame: superview.frame) {
+                let newFrame = computeFrame(arrowPosition: value, refViewFrame: refViewFrame, superviewFrame: superviewFrame)
+                if isFrameValid(newFrame, forRefViewFrame: refViewFrame, withinSuperviewFrame: superviewFrame) {
                     
                     if position != .Any {
                         print("[EasyTipView - Info] The arrow position you chose <\(position)> could not be applied. Instead, position <\(value)> has been applied! Please specify position <\(ArrowPosition.Any)> if you want EasyTipView to choose a position for you.")


### PR DESCRIPTION
If the superview is a scrollview then the child views coordinate system is in the content coordinate system
The scrollview will return the visible frame instead of the content frame so that the tooltip will erroneously adjusted if the `presentingView` is outside the initial viewport.

This PR handles the special case when the `superview` is a `UIScrollView` by using a frame that is representing the scrollviews  content frame.