### PR TITLE
add possibility to arrange (reposition) the tooltip view after adding it

### DIFF
--- a/Source/EasyTipView.swift
+++ b/Source/EasyTipView.swift
@@ -140,6 +140,7 @@ public extension EasyTipView {
         }) { (finished) -> Void in
             completion?()
             self.delegate?.easyTipViewDidDismiss(self)
+            self.preferences.callbacks.dismissed?()
             self.removeFromSuperview()
             self.transform = CGAffineTransform.identity
         }
@@ -196,10 +197,16 @@ open class EasyTipView: UIView {
             public var showDuration         = 0.7
             public var dismissDuration      = 0.7
         }
+
+        public struct Callbacks {
+          public var tapped: (() -> Void)?  = nil
+          public var dismissed: (() -> Void)?  = nil
+        }
         
         public var drawing      = Drawing()
         public var positioning  = Positioning()
         public var animating    = Animating()
+        public var callbacks    = Callbacks()
         public var hasBorder : Bool {
             return drawing.borderWidth > 0 && drawing.borderColor != UIColor.clear
         }
@@ -408,6 +415,7 @@ open class EasyTipView: UIView {
     // MARK:- Callbacks -
     
     func handleTap() {
+        self.preferences.callbacks.tapped?()
         dismiss()
     }
     

--- a/Source/EasyTipView.swift
+++ b/Source/EasyTipView.swift
@@ -350,7 +350,7 @@ open class EasyTipView: UIView {
         return !frame.intersects(forRefViewFrame)
     }
     
-    fileprivate func arrange(withinSuperview superview: UIView) {
+    public func arrange(withinSuperview superview: UIView) {
         
         var position = preferences.drawing.arrowPosition
         


### PR DESCRIPTION
If you are using tooltips on cells in a table view and you add a header dynamically the tooltip will be miss placed. This PR just opens access to the `arrange` function so that is possible to manually rearrange the tooltip after it was created.
