### PR TITLE
Remove development team to address build / code signing issues for submodule

### DIFF
--- a/EasyTipView.xcodeproj/project.pbxproj
+++ b/EasyTipView.xcodeproj/project.pbxproj
@@ -154,7 +154,6 @@
 				TargetAttributes = {
 					1310EC8A1D0C537F0000E71E = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 752CFWL5Y4;
 						LastSwiftMigration = 0800;
 						ProvisioningStyle = Automatic;
 					};
@@ -331,7 +330,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 752CFWL5Y4;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -354,7 +353,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 752CFWL5Y4;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";


### PR DESCRIPTION
When including this project via Carthage submodule, the following build error is generated:

```
=== BUILD TARGET EasyTipView OF PROJECT EasyTipView WITH THE DEFAULT CONFIGURATION (Release) ===

Check dependencies
EasyTipView has conflicting provisioning settings. EasyTipView is automatically signed, but code signing identity iPhone Distribution: Primedia, Inc. has been manually specified. Set the code signing identity value to "iPhone Developer" in the build settings editor, or switch to manual signing in the project editor.
```

To address this problem, you should not specify a specific development team to be used for code signing. This PR removes the development team identifiers from the project file. This will allow other teams to include this lib as a Carthage submodule and not run into the same build errors.