### PR TITLE
adding public method to rearrange

### DIFF
--- a/Source/EasyTipView.swift
+++ b/Source/EasyTipView.swift
@@ -149,12 +149,10 @@ public extension EasyTipView {
     /**
      Rearrange position of the EasyTipView
      
-     To be used in special cases where it may be needed (ie the superview has changed its frame)
-     
-     - parameter animated: whether to animate the possible rearrangement
+     To be used in special cases where it may be needed
     */
-    public func rearrange(animated: Bool) {
-        handleRotation(animated: animated)
+    public func rearrange() {
+        handleRotation()
     }
 }
 
@@ -315,22 +313,14 @@ open class EasyTipView: UIView {
     
     // MARK: - Rotation support -
     
-    func handleRotation(animated: Bool = true) {
+    func handleRotation() {
         guard let sview = superview
             , presentingView != nil else { return }
-        
-        let arrangeClosure = { [weak self] in
-            self?.arrange(withinSuperview: sview)
-            self?.setNeedsDisplay()
-        }
-        
-        if animated {
-            UIView.animate(withDuration: 0.3, animations: { _ in
-                arrangeClosure()
-            })
-        } else {
-            arrangeClosure()
-        }
+
+        UIView.animate(withDuration: 0.3, animations: { _ in
+            self.arrange(withinSuperview: sview)
+            self.setNeedsDisplay()
+        })
     }
     
     // MARK: - Private methods -
@@ -379,12 +369,12 @@ open class EasyTipView: UIView {
     fileprivate func isFrameValid(_ frame: CGRect, forRefViewFrame: CGRect, withinSuperviewFrame: CGRect) -> Bool {
         return !frame.intersects(forRefViewFrame)
     }
-    
+
     fileprivate func arrange(withinSuperview superview: UIView) {
         
         var position = preferences.drawing.arrowPosition
         
-        let refViewFrame = presentingView!.convert(presentingView!.bounds, to: superview);
+        let refViewFrame = presentingView!.convert(presentingView!.bounds, to: superview)
         
         let superviewFrame: CGRect
         if let scrollview = superview as? UIScrollView {

--- a/Source/EasyTipView.swift
+++ b/Source/EasyTipView.swift
@@ -145,6 +145,17 @@ public extension EasyTipView {
             self.transform = CGAffineTransform.identity
         }
     }
+    
+    /**
+     Rearrange position of the EasyTipView
+     
+     To be used in special cases where it may be needed (ie the superview has changed its frame)
+     
+     - parameter animated: whether to animate the possible rearrangement
+    */
+    public func rearrange(animated: Bool) {
+        handleRotation(animated: animated)
+    }
 }
 
 // MARK: - UIGestureRecognizerDelegate implementation
@@ -304,14 +315,22 @@ open class EasyTipView: UIView {
     
     // MARK: - Rotation support -
     
-    func handleRotation() {
+    func handleRotation(animated: Bool = true) {
         guard let sview = superview
             , presentingView != nil else { return }
         
-        UIView.animate(withDuration: 0.3, animations: { _ in
-            self.arrange(withinSuperview: sview)
-            self.setNeedsDisplay()
-        })
+        let arrangeClosure = { [weak self] in
+            self?.arrange(withinSuperview: sview)
+            self?.setNeedsDisplay()
+        }
+        
+        if animated {
+            UIView.animate(withDuration: 0.3, animations: { _ in
+                arrangeClosure()
+            })
+        } else {
+            arrangeClosure()
+        }
     }
     
     // MARK: - Private methods -


### PR DESCRIPTION
Taking over from https://github.com/teodorpatras/EasyTipView/pull/62
Looking into it I found that rather than making the arrange method public, what's really helpful is to have public access to what handleRotation() currently does: no need to pass in the superview, and we get the animation too.