### PR TITLE
Adds Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "EasyTipView",
+    platforms: [
+        .iOS(.v8)
+    ],
+    products: [
+        .library(
+            name: "EasyTipView",
+            targets: ["EasyTipView"])
+    ],
+    targets: [
+        .target(
+            name: "EasyTipView",
+            path: "Source"),
+        .testTarget(
+            name: "EasyTipViewTests",
+            dependencies: [
+                "EasyTipView"
+            ],
+            path: "Tests")
+    ]
+)

--- a/Source/UIKitExtensions.swift
+++ b/Source/UIKitExtensions.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 // MARK: - UIBarItem extension -
 


### PR DESCRIPTION
## 📲 What

Adds SPM support to the library, making it importable using the Xcode 11 integration.

## 🤔 Why

Xcode 11 SPM integration is a really big milestone in the Apple developer community. It allows us to have native dependencies handling (finally!). Libraries should be importable using this new mechanism.

## 🛠 How

Adds an SPM manifest file (Package.swift) and imports UIKit in the extensions file

## ✅ How to test it?

You need to download and install Xcode 11 beta. And import the library using the SPM "Add Package Dependency..." wizard

https://developer.apple.com/videos/play/wwdc2019/410/