### PR TITLE
Turn EasyTipView accessible and adding accesibility label 

### DIFF
--- a/Source/EasyTipView.swift
+++ b/Source/EasyTipView.swift
@@ -346,6 +346,10 @@ open class EasyTipView: UIView {
     
     public convenience init (text: String, preferences: Preferences = EasyTipView.globalPreferences, delegate: EasyTipViewDelegate? = nil) {
         self.init(content: .text(text), preferences: preferences, delegate: delegate)
+        
+        self.isAccessibilityElement = true
+        self.accessibilityTraits = UIAccessibilityTraits.staticText
+        self.accessibilityLabel = text
     }
     
     public convenience init (contentView: UIView, preferences: Preferences = EasyTipView.globalPreferences, delegate: EasyTipViewDelegate? = nil) {


### PR DESCRIPTION
Setting isAccessibilityElement to true and accessibilityTraits to UIAccessibilityTraits.staticText and accessibilityLabel to text passed in the constructor of EasyTipView, with the objective of to facilite UITests, turning EasyTipView accessible in XCTUIElementQueries.