### PR TITLE
Fix y position for smaller texts

### DIFF
--- a/Source/EasyTipView.swift
+++ b/Source/EasyTipView.swift
@@ -413,7 +413,7 @@ open class EasyTipView: UIView {
             yOrigin = refViewFrame.center.y - tipViewSize.height / 2
         case .left:
             xOrigin = refViewFrame.x + refViewFrame.width
-            yOrigin = refViewFrame.y - tipViewSize.height / 2
+            yOrigin = refViewFrame.center.y - tipViewSize.height / 2
         }
         
         var frame = CGRect(x: xOrigin, y: yOrigin, width: tipViewSize.width, height: tipViewSize.height)


### PR DESCRIPTION
Y position is calculated incorrectly when the text size is smaller than the reference UIView's frame
This PR adds a fix to the y position when the arrow position is set `left`
