### PR TITLE
replace precondition with guard to avoid unexpected crashes

### DIFF
--- a/Sources/EasyTipView/EasyTipView.swift
+++ b/Sources/EasyTipView/EasyTipView.swift
@@ -142,11 +142,17 @@ public extension EasyTipView {
     func show(animated: Bool = true, forView view: UIView, withinSuperview superview: UIView? = nil) {
         
         #if TARGET_APP_EXTENSIONS
-        precondition(superview != nil, "The supplied superview parameter cannot be nil for app extensions.")
+        guard superview != nil else {
+            debugPrint("The supplied superview parameter cannot be nil for app extensions.")
+            return
+        }
         
         let superview = superview!
         #else
-        precondition(superview == nil || view.hasSuperview(superview!), "The supplied superview <\(superview!)> is not a direct nor an indirect superview of the supplied reference view <\(view)>. The superview passed to this method should be a direct or an indirect superview of the reference view. To display the tooltip within the main window, ignore the superview parameter.")
+        guard superview == nil || view.hasSuperview(superview!) else {
+            debugPrint("The supplied superview <\(superview!)> is not a direct nor an indirect superview of the supplied reference view <\(view)>. The superview passed to this method should be a direct or an indirect superview of the reference view. To display the tooltip within the main window, ignore the superview parameter.")
+            return
+        }
         
         let superview = superview ?? UIApplication.shared.windows.first!
         #endif


### PR DESCRIPTION
I think you should consider to replace precondition with guard. There might be some cases where superview is not nil but view is not inserted in that superview which will cause a crash. 

EasyTipView is a kind of tool that we give some tips for users. Generally, It doesn't matter whether the EasyTipView Message is displayed or not for application flow. Yes, that is an unexpected behaviour and should be fixed by developer, so we should warn developer with a log message, but not a crash.

It's very similar to Apple's [present(_:animated:completion:)](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621380-present)

If you try to `present` a `viewController` on a `viewController` which has already a `presentedViewcontroller`, it doesn't crash just prints out a warning message, 

`Warning: Attempt to present <UIAlertController: 0x147d2c6b0>  on <SomeViewController: 0x147d614c0> which is already presenting.`