### PR TITLE
Remove unnecessary excludes.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,11 +23,9 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "EasyTipView",
-            dependencies: [],
-            exclude: ["assets", "Example", "Source"]),
+            dependencies: []),
         .testTarget(
             name: "EasyTipViewTests",
-            dependencies: ["EasyTipView"],
-            exclude: ["assets", "Example", "Source"]),
+            dependencies: ["EasyTipView"]),
     ]
 )


### PR DESCRIPTION
- This PR closes #218 by removing unnecessary excludes, since the base path is already `Sources`, so none of those paths are being included in the first place.