### PR TITLE
Fix bubble height with left/right arrow positions

### DIFF
--- a/Sources/EasyTipView/EasyTipView.swift
+++ b/Sources/EasyTipView/EasyTipView.swift
@@ -720,7 +720,7 @@ open class EasyTipView: UIView {
         case .left, .right:
             
             bubbleWidth = tipViewSize.width - preferences.positioning.bubbleInsets.left - preferences.positioning.bubbleInsets.right - preferences.drawing.arrowHeight
-            bubbleHeight = tipViewSize.height - preferences.positioning.bubbleInsets.top - preferences.positioning.bubbleInsets.left
+            bubbleHeight = tipViewSize.height - preferences.positioning.bubbleInsets.top - preferences.positioning.bubbleInsets.bottom
 
             bubbleXOrigin = arrowPosition == .right ? preferences.positioning.bubbleInsets.left : preferences.positioning.bubbleInsets.left + preferences.drawing.arrowHeight
             bubbleYOrigin = preferences.positioning.bubbleInsets.top


### PR DESCRIPTION
When using left or right arrow positions height is calculated incorrectly, resulting in reduced height with text clipping and floating arrow